### PR TITLE
feat: State and Transition interactivity and auto updates

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,10 +15,11 @@
     "sourceType": "module"
   },
   "parser": "@typescript-eslint/parser",
-  "plugins": ["react", "@typescript-eslint", "prettier"],
+  "plugins": ["react", "@typescript-eslint", "prettier", "react-hooks"],
   "rules": {
     "prettier/prettier": ["error"],
     "@typescript-eslint/no-unused-vars": "error",
-    "@typescript-eslint/explicit-function-return-type": "off"
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "react-hooks/exhaustive-deps": "warn"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-react": "^7.34.1",
-    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.6",
     "postcss": "^8.4.38",
     "prettier": "^3.2.5",

--- a/src/components/canvas/settings/PortEditor.tsx
+++ b/src/components/canvas/settings/PortEditor.tsx
@@ -1,5 +1,6 @@
 import {PlusCircledIcon} from '@radix-ui/react-icons';
 import * as Tabs from '@radix-ui/react-tabs';
+import {useCallback, useEffect, useMemo} from 'react';
 
 import {PortCategory, TabSchema} from '../../../constants/ports.constants';
 import {useGlobal} from '../../../contexts/GlobalContext';
@@ -10,6 +11,7 @@ import {
   removeAllNonNumeric,
   removeForbiddenChars,
 } from '../../../utils/input';
+import {getPortLogicObjectFromPorts} from '../../../utils/port.utils';
 import PortElement from './PortElement';
 
 function PortEditor() {
@@ -20,6 +22,7 @@ function PortEditor() {
     setInputList,
     setInternalsList,
     setOutputList,
+    nodeState: {setNodes},
   } = useGlobal();
 
   const PORT_TABS: TabSchema[] = [
@@ -63,6 +66,35 @@ function PortEditor() {
     const newPort = getDefaultPortValues(getList(tab).length + 1, tab);
     getListSetter(tab)(prev => [...prev, newPort]);
   };
+
+  const outputsLogic = useMemo(
+    () => getPortLogicObjectFromPorts(outputList),
+    [outputList],
+  );
+
+  const internalsLogic = useMemo(
+    () => getPortLogicObjectFromPorts(internalsList),
+    [internalsList],
+  );
+
+  const updateNodesState = useCallback(() => {
+    setNodes(prev =>
+      [...prev].map(node => ({
+        ...node,
+        data: {
+          ...node.data,
+          portLogic: {
+            internals: {...internalsLogic},
+            outputs: {...outputsLogic},
+          },
+        },
+      })),
+    );
+  }, [internalsLogic, outputsLogic, setNodes]);
+
+  useEffect(() => {
+    updateNodesState();
+  }, [updateNodesState]);
 
   const deletePort = (
     id: string,

--- a/src/components/canvas/settings/PortEditor.tsx
+++ b/src/components/canvas/settings/PortEditor.tsx
@@ -23,6 +23,7 @@ function PortEditor() {
     setInternalsList,
     setOutputList,
     nodeState: {setNodes},
+    edgeState: {setEdges},
   } = useGlobal();
 
   const PORT_TABS: TabSchema[] = [
@@ -67,6 +68,11 @@ function PortEditor() {
     getListSetter(tab)(prev => [...prev, newPort]);
   };
 
+  const inputLogic = useMemo(
+    () => getPortLogicObjectFromPorts(inputList),
+    [inputList],
+  );
+
   const outputsLogic = useMemo(
     () => getPortLogicObjectFromPorts(outputList),
     [outputList],
@@ -92,9 +98,30 @@ function PortEditor() {
     );
   }, [internalsLogic, outputsLogic, setNodes]);
 
+  const updateEdgesState = useCallback(() => {
+    setEdges(prev =>
+      [...prev].map(edge => {
+        if (edge.data)
+          return {
+            ...edge,
+            data: {
+              ...edge.data,
+              portLogic: {
+                inputs: {...inputLogic},
+                internals: {...internalsLogic},
+                outputs: {...outputsLogic},
+              },
+            },
+          };
+        else return {...edge};
+      }),
+    );
+  }, [inputLogic, internalsLogic, outputsLogic, setEdges]);
+
   useEffect(() => {
     updateNodesState();
-  }, [updateNodesState]);
+    updateEdgesState();
+  }, [updateEdgesState, updateNodesState]);
 
   const deletePort = (
     id: string,

--- a/src/components/canvas/settings/SettingsDialog.tsx
+++ b/src/components/canvas/settings/SettingsDialog.tsx
@@ -33,8 +33,9 @@ function SettingsDialog() {
             in the Canvas.
           </Dialog.Description>
           <Dialog.Description className="mb-4 text-sm font-light text-slate-800">
-            Each update to this Dialog will reset your States. (This will change
-            in a new version. Currently work in progress...)
+            Each update to this Dialog will reset your edits to States and
+            Transitions. (This will change in a new version. Currently work in
+            progress...)
           </Dialog.Description>
           <PortEditor />
         </Dialog.Content>

--- a/src/components/canvas/settings/SettingsDialog.tsx
+++ b/src/components/canvas/settings/SettingsDialog.tsx
@@ -28,6 +28,14 @@ function SettingsDialog() {
           <Dialog.Description className="text-md mb-4 font-light">
             Use this menu to set up the Ports for your FSM
           </Dialog.Description>
+          <Dialog.Description className="mb-2 text-sm font-light text-slate-800">
+            Warning! Set up all your FSM Ports BEFORE customizing yours States
+            in the Canvas.
+          </Dialog.Description>
+          <Dialog.Description className="mb-4 text-sm font-light text-slate-800">
+            Each update to this Dialog will reset your States. (This will change
+            in a new version. Currently work in progress...)
+          </Dialog.Description>
           <PortEditor />
         </Dialog.Content>
       </Dialog.Portal>

--- a/src/components/edges/FloatingEdge.tsx
+++ b/src/components/edges/FloatingEdge.tsx
@@ -1,4 +1,3 @@
-import {CrossCircledIcon} from '@radix-ui/react-icons';
 import {useCallback} from 'react';
 import {
   useStore,
@@ -8,7 +7,9 @@ import {
 } from 'reactflow';
 
 import {useGlobal} from '../../contexts/GlobalContext';
+import FSMTransition from '../../models/transition';
 import {getEdgeParams} from '../../utils/edge.utils';
+import DeleteButton from '../shared/DeleteButton';
 
 function FloatingEdge({
   id,
@@ -17,7 +18,8 @@ function FloatingEdge({
   markerEnd,
   style,
   selected,
-}: EdgeProps) {
+  data,
+}: EdgeProps<FSMTransition>) {
   const {
     edgeState: {setEdges},
   } = useGlobal();
@@ -41,6 +43,9 @@ function FloatingEdge({
     targetY: ty,
   });
 
+  const handleDeleteEdge = () =>
+    setEdges(edges => edges.filter(e => e.id !== id));
+
   return (
     <>
       <path
@@ -56,19 +61,24 @@ function FloatingEdge({
       />
       <EdgeLabelRenderer>
         {selected && (
-          <div className="flex gap-2 rounded-md">
-            <button
-              onClick={() => setEdges(edges => edges.filter(e => e.id !== id))}
-              className="nodrag nopan btn-canvas -top-[50px] rounded-md p-2"
-              style={{
-                position: 'absolute',
-                transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
-                pointerEvents: 'all',
-              }}>
-              Delete <CrossCircledIcon className="ml-2" />
-            </button>
-          </div>
+          <DeleteButton
+            onDelete={handleDeleteEdge}
+            className="-top-[60px]"
+            style={{
+              position: 'absolute',
+              transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+              pointerEvents: 'all',
+            }}
+          />
         )}
+        <div
+          style={{
+            position: 'absolute',
+            transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+          }}
+          className="nodrag nopan rounded-md border-2 border-black bg-white p-2 text-lg font-semibold shadow-md">
+          {`T${data?.transitionNumber}`}
+        </div>
       </EdgeLabelRenderer>
       {/* Used for click area */}
       <path

--- a/src/components/edges/FloatingEdge.tsx
+++ b/src/components/edges/FloatingEdge.tsx
@@ -1,9 +1,26 @@
+import {CrossCircledIcon} from '@radix-ui/react-icons';
 import {useCallback} from 'react';
-import {useStore, getStraightPath, EdgeProps} from 'reactflow';
+import {
+  useStore,
+  getStraightPath,
+  EdgeProps,
+  EdgeLabelRenderer,
+} from 'reactflow';
 
+import {useGlobal} from '../../contexts/GlobalContext';
 import {getEdgeParams} from '../../utils/edge.utils';
 
-function FloatingEdge({id, source, target, markerEnd, style}: EdgeProps) {
+function FloatingEdge({
+  id,
+  source,
+  target,
+  markerEnd,
+  style,
+  selected,
+}: EdgeProps) {
+  const {
+    edgeState: {setEdges},
+  } = useGlobal();
   const sourceNode = useStore(
     useCallback(store => store.nodeInternals.get(source), [source]),
   );
@@ -17,7 +34,7 @@ function FloatingEdge({id, source, target, markerEnd, style}: EdgeProps) {
 
   const {sx, sy, tx, ty} = getEdgeParams(sourceNode, targetNode);
 
-  const [edgePath] = getStraightPath({
+  const [edgePath, labelX, labelY] = getStraightPath({
     sourceX: sx,
     sourceY: sy,
     targetX: tx,
@@ -25,13 +42,42 @@ function FloatingEdge({id, source, target, markerEnd, style}: EdgeProps) {
   });
 
   return (
-    <path
-      id={id}
-      className="react-flow__edge-path"
-      d={edgePath}
-      markerEnd={markerEnd}
-      style={style}
-    />
+    <>
+      <path
+        id={id}
+        className="react-flow__edge-path transition-[stroke-width]"
+        d={edgePath}
+        markerEnd={markerEnd}
+        style={
+          selected
+            ? {...style, strokeWidth: (Number(style?.strokeWidth) ?? 2) + 1}
+            : style
+        }
+      />
+      <EdgeLabelRenderer>
+        {selected && (
+          <div className="flex gap-2 rounded-md">
+            <button
+              onClick={() => setEdges(edges => edges.filter(e => e.id !== id))}
+              className="nodrag nopan btn-canvas -top-[50px] rounded-md p-2"
+              style={{
+                position: 'absolute',
+                transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+                pointerEvents: 'all',
+              }}>
+              Delete <CrossCircledIcon className="ml-2" />
+            </button>
+          </div>
+        )}
+      </EdgeLabelRenderer>
+      {/* Used for click area */}
+      <path
+        id={id}
+        className="react-flow__edge-path"
+        d={edgePath}
+        style={{stroke: 'transparent', strokeWidth: '20px'}}
+      />
+    </>
   );
 }
 

--- a/src/components/nodes/stateNode/StateNode.tsx
+++ b/src/components/nodes/stateNode/StateNode.tsx
@@ -1,4 +1,3 @@
-import {CrossCircledIcon} from '@radix-ui/react-icons';
 import {useMemo} from 'react';
 import {
   NodeProps,
@@ -11,6 +10,7 @@ import {
 import {START_NODE_ID} from '../../../constants/nodes.constants';
 import {useGlobal} from '../../../contexts/GlobalContext';
 import FSMState from '../../../models/state';
+import DeleteButton from '../../shared/DeleteButton';
 import StateNodeHandler from './StateNodeHandler';
 import StateNodeHeader from './StateNodeHeader';
 import StateNodePortList from './StateNodePortList';
@@ -63,11 +63,7 @@ function StateNode({id, selected, data}: NodeProps<FSMState>) {
   return (
     <div>
       <NodeToolbar isVisible={selected} position={Position.Top}>
-        <button
-          onClick={() => handleDeleteNode()}
-          className="nodrag nopan btn-canvas rounded-md p-2">
-          Delete <CrossCircledIcon className="ml-2" />
-        </button>
+        <DeleteButton onDelete={handleDeleteNode} />
       </NodeToolbar>
       <div
         className={`selection: min-w-[180px] rounded-t-md transition-[border-width] ${selectedStyle} border-b-0 border-black bg-slate-100 shadow-md`}>

--- a/src/components/nodes/stateNode/StateNode.tsx
+++ b/src/components/nodes/stateNode/StateNode.tsx
@@ -30,7 +30,7 @@ function StateNode({id, data}: NodeProps<FSMState>) {
 
   const isConnected = useMemo(
     () => !!edges.find(edge => edge.target === id),
-    [edges],
+    [edges, id],
   );
 
   const isStartConnected = useMemo(

--- a/src/components/nodes/stateNode/StateNode.tsx
+++ b/src/components/nodes/stateNode/StateNode.tsx
@@ -1,5 +1,12 @@
+import {CrossCircledIcon} from '@radix-ui/react-icons';
 import {useMemo} from 'react';
-import {NodeProps, useStore, ReactFlowState} from 'reactflow';
+import {
+  NodeProps,
+  useStore,
+  ReactFlowState,
+  NodeToolbar,
+  Position,
+} from 'reactflow';
 
 import {START_NODE_ID} from '../../../constants/nodes.constants';
 import {useGlobal} from '../../../contexts/GlobalContext';
@@ -11,7 +18,7 @@ import StateNodePortList from './StateNodePortList';
 const connectionNodeIdSelector = (state: ReactFlowState) =>
   state.connectionNodeId;
 
-function StateNode({id, data}: NodeProps<FSMState>) {
+function StateNode({id, selected, data}: NodeProps<FSMState>) {
   const connectionNodeId = useStore(connectionNodeIdSelector);
   const {
     stateNumber,
@@ -19,7 +26,8 @@ function StateNode({id, data}: NodeProps<FSMState>) {
     portLogic: {internals, outputs},
   } = data;
   const {
-    edgeState: {edges},
+    edgeState: {edges, setEdges},
+    nodeState: {setNodes},
   } = useGlobal();
 
   const outputsList = Object.values(outputs);
@@ -43,9 +51,26 @@ function StateNode({id, data}: NodeProps<FSMState>) {
     !!connectionNodeId &&
     connectionNodeId === START_NODE_ID;
 
+  const selectedStyle = selected ? 'border-4' : 'border-2';
+
+  const handleDeleteNode = () => {
+    setNodes(nodes => nodes.filter(node => node.id !== id));
+    setEdges(edges =>
+      edges.filter(edge => edge.target !== id && edge.source !== id),
+    );
+  };
+
   return (
     <div>
-      <div className="min-w-[180px] rounded-t-md border-2 border-b-0 border-black bg-slate-100 shadow-md">
+      <NodeToolbar isVisible={selected} position={Position.Top}>
+        <button
+          onClick={() => handleDeleteNode()}
+          className="nodrag nopan btn-canvas rounded-md p-2">
+          Delete <CrossCircledIcon className="ml-2" />
+        </button>
+      </NodeToolbar>
+      <div
+        className={`selection: min-w-[180px] rounded-t-md transition-[border-width] ${selectedStyle} border-b-0 border-black bg-slate-100 shadow-md`}>
         <StateNodeHeader stateNumber={stateNumber} name={name} />
         <StateNodePortList
           outputsList={outputsList}
@@ -57,6 +82,7 @@ function StateNode({id, data}: NodeProps<FSMState>) {
         isNotAllowed={isStartTryingToConnectAgain}
         isPossibleTarget={isPossibleTarget}
         isConnected={isConnected}
+        selectedStyle={selectedStyle}
       />
     </div>
   );

--- a/src/components/nodes/stateNode/StateNodeHandler.tsx
+++ b/src/components/nodes/stateNode/StateNodeHandler.tsx
@@ -6,6 +6,7 @@ interface StateNodeHandlerProps {
   isNotAllowed: boolean;
   isPossibleTarget: boolean;
   isConnected: boolean;
+  selectedStyle: string;
 }
 
 const StateNodeHandler = ({
@@ -13,6 +14,7 @@ const StateNodeHandler = ({
   isNotAllowed,
   isPossibleTarget,
   isConnected,
+  selectedStyle,
 }: StateNodeHandlerProps) => {
   const targetStyle = isPossibleTarget
     ? isNotAllowed
@@ -24,7 +26,7 @@ const StateNodeHandler = ({
 
   return (
     <div
-      className={`relative flex flex-col rounded-b-md border-2 border-black/80 px-2 py-3 transition-colors ${targetStyle}`}>
+      className={`relative flex flex-col rounded-b-md border-black/80 px-2 py-3 transition-colors ${targetStyle} transition-[border-width] ${selectedStyle}`}>
       <HiddenHandle isConnecting={isConnecting} type={NODE_TYPE.State} />
       <h1 className="text-center font-semibold uppercase text-black">
         {!isNotAllowed ? label : 'Not allowed'}

--- a/src/components/nodes/stateNode/StateNodeHeader.tsx
+++ b/src/components/nodes/stateNode/StateNodeHeader.tsx
@@ -7,7 +7,7 @@ function StateNodeHeader({stateNumber, name}: StateNodeHeaderProps) {
   return (
     <div className="flex justify-between border-b-2 border-black">
       <div className="flex-1 border-r-[1px] border-black p-2 text-center font-bold">
-        {stateNumber}
+        {`S${stateNumber}`}
       </div>
       <div className="flex-[5] border-l-[1px] border-black p-2">{name}</div>
     </div>

--- a/src/components/shared/DeleteButton.tsx
+++ b/src/components/shared/DeleteButton.tsx
@@ -1,0 +1,19 @@
+import {CrossCircledIcon} from '@radix-ui/react-icons';
+
+interface DeleteButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  onDelete: () => void;
+}
+
+const DeleteButton = ({onDelete, className, ...rest}: DeleteButtonProps) => {
+  return (
+    <button
+      onClick={() => onDelete()}
+      className={`nodrag nopan btn-canvas rounded-md border-2 border-black p-2 text-lg font-bold ${className}`}
+      {...rest}>
+      Delete <CrossCircledIcon className="ml-2" />
+    </button>
+  );
+};
+
+export default DeleteButton;

--- a/src/contexts/GlobalContext.tsx
+++ b/src/contexts/GlobalContext.tsx
@@ -11,6 +11,7 @@ import {
 import {INITIAL_NODES} from '../constants/nodes.constants';
 import Port from '../models/port';
 import FSMState from '../models/state';
+import FSMTransition from '../models/transition';
 
 export type GlobalContextType = {
   settingsOpen: boolean;
@@ -27,8 +28,8 @@ export type GlobalContextType = {
     onNodesChange: (changes: NodeChange[]) => void;
   };
   edgeState: {
-    edges: Edge<unknown>[];
-    setEdges: React.Dispatch<React.SetStateAction<Edge<unknown>[]>>;
+    edges: Edge<FSMTransition>[];
+    setEdges: React.Dispatch<React.SetStateAction<Edge<FSMTransition>[]>>;
     onEdgesChange: (changes: EdgeChange[]) => void;
   };
 };

--- a/src/models/state.ts
+++ b/src/models/state.ts
@@ -18,13 +18,15 @@ export interface PortLogic {
   customValue?: PortValue;
 }
 
+export interface StatePortLogic {
+  outputs: {[key: string]: PortLogic};
+  internals: {[key: string]: PortLogic};
+}
+
 interface FSMState {
   stateNumber: number;
   name: string;
-  portLogic: {
-    outputs: {[key: string]: PortLogic};
-    internals: {[key: string]: PortLogic};
-  };
+  portLogic: StatePortLogic;
   isStart?: boolean;
 }
 

--- a/src/models/state.ts
+++ b/src/models/state.ts
@@ -1,6 +1,6 @@
 import Port, {PortValue} from './port';
 
-export enum PortLogicType {
+export enum LogicType {
   Equality = 'equality',
   LogicNot = 'logic_not',
   LogicOr = 'logic_or',
@@ -14,7 +14,7 @@ export enum PortLogicType {
 
 export interface PortLogic {
   port: Port;
-  type: PortLogicType;
+  type: LogicType;
   customValue?: PortValue;
 }
 

--- a/src/models/transition.ts
+++ b/src/models/transition.ts
@@ -1,0 +1,13 @@
+import {PortLogic, StatePortLogic} from './state';
+
+export interface TransitionPortLogic extends StatePortLogic {
+  inputs: {[key: string]: PortLogic};
+}
+
+interface FSMTransition {
+  transitionNumber: number;
+  name: string;
+  portLogic: TransitionPortLogic;
+}
+
+export default FSMTransition;

--- a/src/routes/Canvas.tsx
+++ b/src/routes/Canvas.tsx
@@ -58,9 +58,12 @@ function Canvas() {
     [edges],
   );
 
-  const onConnect = useCallback((connection: Connection) => {
-    setEdges(edges => addEdge(connection, edges));
-  }, []);
+  const onConnect = useCallback(
+    (connection: Connection) => {
+      setEdges(edges => addEdge(connection, edges));
+    },
+    [setEdges],
+  );
 
   const outputsLogic = useMemo(
     () => getPortLogicObjectFromPorts(outputList),
@@ -93,7 +96,7 @@ function Canvas() {
       ]);
       setTotalCount(newCount);
     },
-    [internalsLogic, outputsLogic, totalCount],
+    [internalsLogic, outputsLogic, setNodes, totalCount],
   );
 
   const onDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
@@ -138,16 +141,19 @@ function Canvas() {
       edgeUpdateSuccessful.current = true;
       setEdges(els => updateEdge(oldEdge, newConnection, els));
     },
-    [],
+    [setEdges],
   );
 
-  const onEdgeUpdateEnd = useCallback((_: unknown, edge: Edge<unknown>) => {
-    if (!edgeUpdateSuccessful.current) {
-      setEdges(eds => eds.filter(e => e.id !== edge.id));
-    }
+  const onEdgeUpdateEnd = useCallback(
+    (_: unknown, edge: Edge<unknown>) => {
+      if (!edgeUpdateSuccessful.current) {
+        setEdges(eds => eds.filter(e => e.id !== edge.id));
+      }
 
-    edgeUpdateSuccessful.current = true;
-  }, []);
+      edgeUpdateSuccessful.current = true;
+    },
+    [setEdges],
+  );
 
   return (
     <div className="flex-1 bg-slate-100">

--- a/src/routes/Canvas.tsx
+++ b/src/routes/Canvas.tsx
@@ -179,6 +179,7 @@ function Canvas() {
           onInit={e => setReactFlowInstance(e)}
           onDrop={onDrop}
           onDragOver={onDragOver}
+          deleteKeyCode={['Delete', 'Shift']}
           fitView>
           <Background gap={12} size={2} color={zinc[200]} />
           <Controls position="bottom-right" />

--- a/src/routes/Canvas.tsx
+++ b/src/routes/Canvas.tsx
@@ -165,7 +165,7 @@ function Canvas() {
   }, []);
 
   const onEdgeUpdate = useCallback(
-    (oldEdge: Edge<unknown>, newConnection: Connection) => {
+    (oldEdge: Edge<FSMTransition>, newConnection: Connection) => {
       edgeUpdateSuccessful.current = true;
       setEdges(els => updateEdge(oldEdge, newConnection, els));
     },
@@ -173,7 +173,7 @@ function Canvas() {
   );
 
   const onEdgeUpdateEnd = useCallback(
-    (_: unknown, edge: Edge<unknown>) => {
+    (_: unknown, edge: Edge<FSMTransition>) => {
       if (!edgeUpdateSuccessful.current) {
         setEdges(eds => eds.filter(e => e.id !== edge.id));
       }

--- a/src/utils/port.utils.ts
+++ b/src/utils/port.utils.ts
@@ -1,5 +1,5 @@
 import Port from '../models/port';
-import {PortLogic, PortLogicType} from '../models/state';
+import {PortLogic, LogicType} from '../models/state';
 
 export function getPortLogicObjectFromPorts(ports: Port[]): {
   [key: string]: PortLogic;
@@ -8,7 +8,7 @@ export function getPortLogicObjectFromPorts(ports: Port[]): {
   ports.forEach(port => {
     portLogic = {
       ...portLogic,
-      [port.id]: {port, type: PortLogicType.Default},
+      [port.id]: {port, type: LogicType.Default},
     };
   });
   return portLogic;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2267,10 +2267,10 @@ eslint-plugin-promise@^6.0.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz#269a3e2772f62875661220631bd4dafcb4083816"
   integrity sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==
 
-eslint-plugin-react-hooks@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
-  integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
+eslint-plugin-react-hooks@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz#c829eb06c0e6f484b3fbb85a97e57784f328c596"
+  integrity sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==
 
 eslint-plugin-react-refresh@^0.4.6:
   version "0.4.6"


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

## Additions

- New delete button for States and Transitions
- New behavior for settings dialog, will now update all Nodes and Edges
- Style improvements

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
